### PR TITLE
Remove profile image backend API

### DIFF
--- a/jasao-server/src/main/kotlin/io/yeahx4/jasao/controller/file/UploadedFileController.kt
+++ b/jasao-server/src/main/kotlin/io/yeahx4/jasao/controller/file/UploadedFileController.kt
@@ -57,13 +57,13 @@ class UploadedFileController(
         val dbUser = this.userService.getUserById(user.id)!!
 
         if (!this.uploadedFileService.deleteProfileImage(user.id, user.profile.endsWith(".jpg"))) {
-            this.logger.warn("User ${user.id} tried to delete non-exist profile image.")
+            this.logger.warn("User ${user.id} tried to delete non-exist profile image")
             return Res(HttpResponse("File not exists", null), HttpStatus.BAD_REQUEST)
         } else {
             dbUser.profile = ""
         }
 
-        this.logger.info("User ${user.id} removed its profile image.")
+        this.logger.info("User ${user.id} removed its profile image")
         return Res(HttpResponse("Ok", null), HttpStatus.OK)
     }
 }

--- a/jasao-server/src/main/kotlin/io/yeahx4/jasao/controller/file/UploadedFileController.kt
+++ b/jasao-server/src/main/kotlin/io/yeahx4/jasao/controller/file/UploadedFileController.kt
@@ -8,6 +8,7 @@ import io.yeahx4.jasao.util.Res
 import jakarta.transaction.Transactional
 import org.slf4j.LoggerFactory
 import org.springframework.http.HttpStatus
+import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestHeader
@@ -47,5 +48,22 @@ class UploadedFileController(
 
             Res(HttpResponse("Invalid role", null), HttpStatus.BAD_REQUEST)
         }
+    }
+
+    @DeleteMapping("/auth/profile/delete")
+    @Transactional
+    fun deleteProfileImage(@RequestHeader("Authorization") jwt: String): Res<String> {
+        val user = this.jwtService.getUserFromToken(jwt);
+        val dbUser = this.userService.getUserById(user.id)!!
+
+        if (!this.uploadedFileService.deleteProfileImage(user.id, user.profile.endsWith(".jpg"))) {
+            this.logger.warn("User ${user.id} tried to delete non-exist profile image.")
+            return Res(HttpResponse("File not exists", null), HttpStatus.BAD_REQUEST)
+        } else {
+            dbUser.profile = ""
+        }
+
+        this.logger.info("User ${user.id} removed its profile image.")
+        return Res(HttpResponse("Ok", null), HttpStatus.OK)
     }
 }

--- a/jasao-server/src/main/kotlin/io/yeahx4/jasao/controller/user/UserController.kt
+++ b/jasao-server/src/main/kotlin/io/yeahx4/jasao/controller/user/UserController.kt
@@ -266,6 +266,7 @@ class UserController(
         val user = this.userService.getUserById(id)
             ?: return Res(HttpResponse("Not Found", null), HttpStatus.NOT_FOUND)
 
+        this.logger.info("User ${id} profile request")
         return Res(HttpResponse("Ok", user.toDto()), HttpStatus.OK)
     }
 
@@ -273,6 +274,7 @@ class UserController(
     fun getMyProfile(@RequestHeader("Authorization") jwt: String): Res<UserDto> {
         val user = this.jwtService.getUserFromToken(jwt)
 
+        this.logger.info("User ${user.id} self identification")
         return Res(HttpResponse("Ok", user.toDto()), HttpStatus.OK)
     }
 }

--- a/jasao-server/src/main/kotlin/io/yeahx4/jasao/service/file/UploadedFileService.kt
+++ b/jasao-server/src/main/kotlin/io/yeahx4/jasao/service/file/UploadedFileService.kt
@@ -43,4 +43,23 @@ class UploadedFileService(private val uploadedFileRepository: UploadedFileReposi
 
         return "/images/${owner}/profile${ext}"
     }
+
+    fun deleteProfileImage(user: Long, isJgp: Boolean): Boolean {
+        val path = arrayOf(
+            System.getProperty("user.dir"),
+            "..",
+            "cdn",
+            "public",
+            "images",
+            user.toString(),
+            "profile" + (if (isJgp) ".jpg" else ".png")
+        ).joinToString(File.separator)
+        val file = File(path)
+
+        return if (!file.exists()) {
+            false
+        } else {
+            file.delete()
+        }
+    }
 }


### PR DESCRIPTION
New API
```http
DELETE /file/auth/profile/delete
```

This will delete profile image of user who is logged in currently if it exists. Unless, return `400 Bad Request`. If this request successfully completed, column of DB is changed and file of CDN is deleted.

Antecedent of #83 